### PR TITLE
Added ceil function so that R can be used to index elements even if it is not an integer.

### DIFF
--- a/R1DL.py
+++ b/R1DL.py
@@ -1,6 +1,7 @@
 import argparse
 import numpy as np
 import numpy.linalg as sla
+from math import ceil
 
 def op_selectTopR(vct_input, R):
     """
@@ -29,8 +30,8 @@ def op_selectTopR(vct_input, R):
         indices will be stored and returned as major
         output of the function.
     """
-    temp = np.argpartition(-vct_input, R)
-    idxs_n = temp[:R]
+    temp = np.argpartition(-vct_input, ceil(R))
+    idxs_n = temp[:ceil(R)]
     return idxs_n
 
 def op_getResidual(S, u, v, idxs_n):


### PR DESCRIPTION
I noticed that the R value used in the op_selectTopR function was passed R values which were percentages and sometimes if you have a small dictionary, the resulting R value turns out to be really small and this necessitates the addition of the 'ceil' function so that you can round of the fractional numbers to the nearest integers.